### PR TITLE
Update android namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    android.namespace = "org.torusresearch.flutter.customauth"
     compileSdkVersion 32
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/ios/customauth_flutter.podspec
+++ b/ios/customauth_flutter.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'CustomAuth', '~> 5.0.0'
+  s.dependency 'CustomAuth', '~> 6.0.0'
   s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
This resolves the following issue:

```
The plugin `customauth_flutter` doesn't have a main class defined in ~/.pub-cache/hosted/pub.dev/customauth_flutter-3.0.1/android/src/main/java/org/torusresearch/flutter/customauth/CustomAuthPlugin.java or ~/.pub-cache/hosted/pub.dev/customauth_flutter-3.0.1/android/src/main/kotlin/org/torusresearch/flutter/customauth/CustomAuthPlugin.kt. This is likely to due to an incorrect `androidPackage: org.torusresearch.flutter.customauth` or `mainClass` entry in the plugin's pubspec.yaml.
If you are the author of this plugin, fix the `androidPackage` entry or move the main class to any of locations used above. Otherwise, please contact the author of this plugin and consider using a different plugin in the meanwhile. 
```